### PR TITLE
MWarrener patch 1

### DIFF
--- a/dbsp.py
+++ b/dbsp.py
@@ -599,7 +599,7 @@ def store_standards(imgID_list, side='blue', trace=None,
     caldir : string, default "onedstds$iidscal/"
         Directory to search for calibration standards in.
     crval : int or None (default)
-        Spectrum reference dispersion coordinate, if different from defaultpyfits
+        Spectrum reference dispersion coordinate, if different from default
         [Angstroms of central pixel]
     cdelt : int or None (default)
         Spectral dispersion, if different from default [Angstroms per pixel]


### PR DESCRIPTION
iraf.hselect does not fail if nothing is returned; it just returns an empty array, which then causes iraf.imcombine to fail. Replaced try-except block to exhibit the desired behavior in make_blue_side and make_red_side.

Also includes sky-lines fix we discussed via email